### PR TITLE
Update rlpvalue_write.cpp

### DIFF
--- a/lib/rlpvalue_write.cpp
+++ b/lib/rlpvalue_write.cpp
@@ -49,12 +49,11 @@ static std::string encodeLength(size_t n, unsigned char offset)
 
 	else {
 		// assert(n too big);
-
 		std::string binlen = encodeBinary(n);
-		rs.append(binlen);
 
 		unsigned char ch = binlen.size() + offset + 55;
 		rs.assign((const char *) &ch, 1);
+		rs.append(binlen);
 	}
 
 	return rs;


### PR DESCRIPTION
fix long string >= 56 serialization case

Looks like tests does not checks serialization, only deserialization.